### PR TITLE
Use reference for UnknownTeamMemberReferenceError

### DIFF
--- a/lib/team_api/joiner.rb
+++ b/lib/team_api/joiner.rb
@@ -110,7 +110,7 @@ module TeamApi
       (team_list || []).map! do |reference|
         member = team_member_from_reference reference
         if member.nil?
-          fail UnknownTeamMemberReferenceError, member unless public_mode
+          fail UnknownTeamMemberReferenceError, reference unless public_mode
         else
           member['name']
         end

--- a/test/joiner_join_team_list_test.rb
+++ b/test/joiner_join_team_list_test.rb
@@ -46,9 +46,10 @@ module TeamApi
 
     def test_join_raises_if_identifier_unknown
       impl = JoinerImpl.new @site
-      assert_raises(UnknownTeamMemberReferenceError) do
+      error = assert_raises(UnknownTeamMemberReferenceError) do
         impl.join_team_list(%w(mbland alison@18f.gov jmcarp foobar))
       end
+      assert_equal 'foobar', error.message
     end
 
     def test_join_ignores_unknown_identifiers_in_public_mode


### PR DESCRIPTION
Using the nil `member` value didn't prove very helpful in stack traces.

cc: @arowla @gboone 