### PR TITLE
Use the `full_name` field for project cross-refs

### DIFF
--- a/lib/team_api/cross_referencer.rb
+++ b/lib/team_api/cross_referencer.rb
@@ -110,7 +110,7 @@ module TeamApi
   # Builds cross-references between data sets.
   class CrossReferencer
     TEAM_FIELDS = %w(name last_name first_name full_name self)
-    PROJECT_FIELDS = %w(name project self)
+    PROJECT_FIELDS = %w(name full_name self)
     WORKING_GROUP_FIELDS = %w(name full_name self)
     GUILD_FIELDS = %w(name full_name self)
     TAG_CATEGORIES = %w(skills interests)


### PR DESCRIPTION
Turns out we renamed `project` to `full_name` and forgot to update this. Longer-term, I want to push all this cross-reference configuration into the `endpoints.yml` file, but that's a bigger change for another time.

cc: @monfresh @arowla 