### PR TITLE
Flesh out skills, interests cross-refs for team members

### DIFF
--- a/lib/team_api/canonicalizer.rb
+++ b/lib/team_api/canonicalizer.rb
@@ -12,8 +12,9 @@ module TeamApi
       %w(skills interests).each do |category|
         xrefs = site_data[category]
         canonicalize_tag_category xrefs
-        team_members = site_data['team'].values
-        team_members.each { |i| canonicalize_tags_for_item category, xrefs, i }
+        site_data['team'].values.each do |member|
+          canonicalize_tags_for_item category, xrefs, member
+        end
       end
     end
 
@@ -127,8 +128,9 @@ module TeamApi
     private_class_method :consolidate_xrefs
 
     def self.canonicalize_tags_for_item(category, xrefs, item)
-      (item[category] || []).each { |t| t['name'] = xrefs[t['slug']]['name'] }
-        .sort_by! { |xref| xref['name'] }
+      return if item[category].nil?
+      item[category].each { |tag| tag['name'] = xrefs[tag['slug']]['name'] }
+        .sort_by! { |tag| tag['name'] }
     end
   end
 end

--- a/lib/team_api/canonicalizer.rb
+++ b/lib/team_api/canonicalizer.rb
@@ -9,8 +9,12 @@ module TeamApi
     # Canonicalizes the order and names of certain fields within site_data.
     def self.canonicalize_data(site_data)
       sort_collections site_data
-      canonicalize_tag_category site_data['skills']
-      canonicalize_tag_category site_data['interests']
+      %w(skills interests).each do |category|
+        xrefs = site_data[category]
+        canonicalize_tag_category xrefs
+        team_members = site_data['team'].values
+        team_members.each { |i| canonicalize_tags_for_item category, xrefs, i }
+      end
     end
 
     def self.sort_collections(site_data)
@@ -121,5 +125,10 @@ module TeamApi
       [slug, result]
     end
     private_class_method :consolidate_xrefs
+
+    def self.canonicalize_tags_for_item(category, xrefs, item)
+      (item[category] || []).each { |t| t['name'] = xrefs[t['slug']]['name'] }
+        .sort_by! { |xref| xref['name'] }
+    end
   end
 end

--- a/test/canonicalizer_tag_categories_test.rb
+++ b/test/canonicalizer_tag_categories_test.rb
@@ -5,24 +5,7 @@ require_relative './site'
 require 'minitest/autorun'
 
 module TeamApi
-  class CanonicalizeTagCategoryTest < ::Minitest::Test
-    attr_accessor :site
-
-    def setup
-      @site = DummyTestSite.new
-    end
-
-    def test_empty_team
-      Canonicalizer.canonicalize_tag_category site.data['skills']
-      refute site.data['skills']
-    end
-
-    def test_empty_skills
-      site.data['skills'] = {}
-      Canonicalizer.canonicalize_tag_category site.data['skills']
-      assert_empty site.data['skills']
-    end
-
+  class CanonicalizeTagTestData
     def c_plus_plus
       { 'C++' =>
         { 'name' => 'C++', 'slug' => 'c++',
@@ -50,6 +33,10 @@ module TeamApi
       }
     end
 
+    def all_ruby
+      ruby_uppercase.merge ruby_lowercase
+    end
+
     def ruby_consolidated
       { 'ruby' =>
           { 'name' => 'Ruby', 'slug' => 'ruby',
@@ -62,38 +49,57 @@ module TeamApi
       }
     end
 
-    CANONICALIZED_XREFS = %w(C++ Ruby).map do |skill|
-      slug = skill.downcase
-      self_url = "https://team-api.18f.gov/api/skills/#{slug}"
-      [slug, { 'name' => skill, 'slug' => slug, 'self' => self_url }]
-    end.to_h
+    def all_skills
+      c_plus_plus.merge(ruby_uppercase).merge(ruby_lowercase)
+    end
+
+    def consolidated_skills
+      ruby_consolidated.merge('c++' => c_plus_plus['C++'])
+    end
+  end
+
+  class CanonicalizeTagCategoryTest < ::Minitest::Test
+    attr_accessor :site, :tag_test_data
+
+    def setup
+      @site = DummyTestSite.new
+      @tag_test_data = CanonicalizeTagTestData.new
+    end
+
+    def test_empty_team
+      Canonicalizer.canonicalize_tag_category site.data['skills']
+      refute site.data['skills']
+    end
+
+    def test_empty_skills
+      site.data['skills'] = {}
+      Canonicalizer.canonicalize_tag_category site.data['skills']
+      assert_empty site.data['skills']
+    end
 
     def test_single_skill
-      site.data['skills'] = c_plus_plus
+      cpp_data = tag_test_data.c_plus_plus
+      site.data['skills'] = cpp_data
+      expected = { 'c++' => cpp_data['C++'] }
       Canonicalizer.canonicalize_tag_category site.data['skills']
-      expected = { 'c++' => c_plus_plus['C++'] }
       assert_equal expected, site.data['skills']
     end
 
     def test_single_skill_multiple_names
-      site.data['skills'] = ruby_uppercase.merge(ruby_lowercase)
+      site.data['skills'] = tag_test_data.all_ruby
       Canonicalizer.canonicalize_tag_category site.data['skills']
-      assert_equal ruby_consolidated, site.data['skills']
-    end
-
-    def all_consolidated
-      c_plus_plus.merge(ruby_uppercase).merge(ruby_lowercase)
-    end
-
-    def expected_consolidated
-      ruby_consolidated.merge('c++' => c_plus_plus['C++'])
+      assert_equal tag_test_data.ruby_consolidated, site.data['skills']
     end
 
     def test_multiple_skills
-      site.data['skills'] = all_consolidated
+      site.data['skills'] = tag_test_data.all_skills
       Canonicalizer.canonicalize_tag_category site.data['skills']
-      assert_equal expected_consolidated, site.data['skills']
+      assert_equal tag_test_data.consolidated_skills, site.data['skills']
     end
+  end
+
+  class CanonicalizeTagsForItemTest < ::Minitest::Test
+    attr_accessor :site, :tag_test_data
 
     SELF_URL = 'https://team-api.18f.gov/api/skills/'
     TEAM_MEMBER = {
@@ -103,10 +109,15 @@ module TeamApi
       ],
     }
 
+    def setup
+      @site = DummyTestSite.new
+      @tag_test_data = CanonicalizeTagTestData.new
+    end
+
     def test_canonicalize_tag_xrefs_empty_input
       empty_member = {}
       Canonicalizer.canonicalize_tags_for_item(
-        'skills', expected_consolidated, empty_member)
+        'skills', tag_test_data.consolidated_skills, empty_member)
       assert_nil empty_member['skills']
     end
 
@@ -116,7 +127,7 @@ module TeamApi
         { 'name' => 'Ruby', 'slug' => 'ruby', 'self' => SELF_URL + 'ruby' },
       ]
       Canonicalizer.canonicalize_tags_for_item(
-        'skills', expected_consolidated, TEAM_MEMBER)
+        'skills', tag_test_data.consolidated_skills, TEAM_MEMBER)
       assert_equal expected, TEAM_MEMBER['skills']
     end
   end

--- a/test/cross_reference_tags_test.rb
+++ b/test/cross_reference_tags_test.rb
@@ -20,6 +20,26 @@ module TeamApi
         'skills' => %w(Ruby JavaScript) },
     }
 
+    def self.skill_data(skill, members)
+      slug = Canonicalizer.canonicalize(skill)
+      { 'name' => skill,
+        'slug' => slug,
+        'self' => File.join('https://team-api.18f.gov/api/skills', slug),
+        'members' => Canonicalizer.team_xrefs(TEAM, members),
+      }
+    end
+
+    SKILLS = {
+      'C++' => %w(mbland),
+      'Python' => %w(arowla mbland),
+      'Go' => %w(mbland),
+      'Ruby' => %w(afeld arowla mbland),
+      'Node' => %w(arowla mbland),
+      'JavaScript' => %w(afeld),
+    }.map { |skill, members| [skill, skill_data(skill, members)] }.to_h
+
+    SKILL_XREF_FIELDS = CrossReferencer::TAG_XREF_FIELDS
+
     def setup
       @site = DummyTestSite.new config: { 'baseurl' => '/' }
       @xref = CrossReferenceData.new site, 'team', %w(name full_name)
@@ -41,26 +61,6 @@ module TeamApi
       CrossReferencer.xref_tags_and_team_members site, ['skills'], xref
       refute site.data['skills']
     end
-
-    def self.skill_data(skill, members)
-      slug = Canonicalizer.canonicalize(skill)
-      { 'name' => skill,
-        'slug' => slug,
-        'self' => File.join('https://team-api.18f.gov/api/skills', slug),
-        'members' => Canonicalizer.team_xrefs(TEAM, members),
-      }
-    end
-
-    SKILLS = {
-      'C++' => %w(mbland),
-      'Python' => %w(arowla mbland),
-      'Go' => %w(mbland),
-      'Ruby' => %w(afeld arowla mbland),
-      'Node' => %w(arowla mbland),
-      'JavaScript' => %w(afeld),
-    }.map { |skill, members| [skill, skill_data(skill, members)] }.to_h
-
-    SKILL_XREF_FIELDS = CrossReferencer::TAG_XREF_FIELDS
 
     def member_skills(name)
       SKILLS.select { |_, d| d['members'].detect { |m| m['name'] == name } }

--- a/test/cross_reference_tags_test.rb
+++ b/test/cross_reference_tags_test.rb
@@ -42,7 +42,7 @@ module TeamApi
       refute site.data['skills']
     end
 
-    def self.skill_ref(skill, members)
+    def self.skill_data(skill, members)
       slug = Canonicalizer.canonicalize(skill)
       { 'name' => skill,
         'slug' => slug,
@@ -58,12 +58,20 @@ module TeamApi
       'Ruby' => %w(afeld arowla mbland),
       'Node' => %w(arowla mbland),
       'JavaScript' => %w(afeld),
-    }.map { |skill, members| [skill, skill_ref(skill, members)] }.to_h
+    }.map { |skill, members| [skill, skill_data(skill, members)] }.to_h
+
+    SKILL_XREF_FIELDS = CrossReferencer::TAG_XREF_FIELDS
+
+    def member_skills(name)
+      SKILLS.select { |_, d| d['members'].detect { |m| m['name'] == name } }
+        .map { |_, xref| xref.select { |key| SKILL_XREF_FIELDS.include? key } }
+    end
 
     def test_team_skills
       site.data['team'] = TEAM
       CrossReferencer.xref_tags_and_team_members site, ['skills'], xref
       assert_equal SKILLS, site.data['skills']
+      assert_equal member_skills('mbland'), TEAM['mbland']['skills']
     end
   end
 end


### PR DESCRIPTION
This is a two part process:

- First, in `replace_item_tags_with_xrefs` from `cross_referencer.rb`, the list of tags for each team member are converted from strings to hashes containing the cross-reference information for each tag (`name`, `slug`, and `self`).
- Then, in `canonicalize_tags_for_item` from `canonicalizer.rb`, once the master list of tags have been consolidated (e.g. in `site.data['skills']` "ruby" and "Ruby" are merged into a single "Ruby" item), then the cross-references in each team member are updated to use the consolidated name (e.g. "Ruby") and then sorted based on that name.

cc: @arowla @monfresh @jessieay 