### PR TITLE
Allow `id` as a team member identifier field

### DIFF
--- a/lib/team_api/joiner.rb
+++ b/lib/team_api/joiner.rb
@@ -119,7 +119,7 @@ module TeamApi
 
     def team_member_from_reference(reference)
       key = (reference.instance_of? String) ? reference : (
-        reference['email'] || reference['github'])
+        reference['id'] || reference['email'] || reference['github'])
       team[key] || team[team_by_email[key] || team_by_github[key]]
     end
 

--- a/test/joiner_join_team_list_test.rb
+++ b/test/joiner_join_team_list_test.rb
@@ -12,6 +12,7 @@ module TeamApi
         'mbland' => { 'name' => 'mbland' },
         'alison' => { 'name' => 'alison', 'email' => 'alison@18f.gov' },
         'joshcarp' => { 'name' => 'joshcarp', 'github' => 'jmcarp' },
+        'boone' => { 'name' => 'boone' },
       }
     end
 
@@ -39,9 +40,13 @@ module TeamApi
 
     def test_join_team_containing_hashes
       impl = JoinerImpl.new @site
-      assert_equal(%w(mbland alison joshcarp),
+      assert_equal(%w(mbland alison joshcarp boone),
         impl.join_team_list([
-          'mbland', { 'email' => 'alison@18f.gov' }, { 'github' => 'jmcarp' }]))
+          'mbland',
+          { 'email' => 'alison@18f.gov' },
+          { 'github' => 'jmcarp' },
+          { 'id' => 'boone' },
+        ]))
     end
 
     def test_join_raises_if_identifier_unknown


### PR DESCRIPTION
This precipitates from 18F/18f.gsa.gov#1185, whereby the .about.yml schema
permits `team :` members to be idenfied by `id`, leading to an import failure
in team-api.18f.gov.

This also reminds me that we may want to change `name:` to `id:` everywhere,
rather than `username:` per #9.

cc: @gboone @jessieay @arowla @monfresh 