### PR TITLE
Build team indexes before filtering private data

### DIFF
--- a/lib/team_api/joiner.rb
+++ b/lib/team_api/joiner.rb
@@ -20,6 +20,7 @@ module TeamApi
     def self.join_data(site)
       impl = JoinerImpl.new site
       site.data.merge! impl.collection_data
+      impl.create_indexes
       impl.promote_or_remove_data
       impl.join_project_data
       Api.add_self_links site
@@ -81,6 +82,11 @@ module TeamApi
       data['team'] ||= {}
     end
 
+    def create_indexes
+      team_by_email
+      team_by_github
+    end
+
     # Returns an index of team member usernames keyed by email address.
     def team_by_email
       @team_by_email ||= team_index_by_field 'email'
@@ -93,10 +99,19 @@ module TeamApi
 
     # Returns an index of team member usernames keyed by a particular field.
     def team_index_by_field(field)
-      team.values.map do |member|
+      team_members.map do |member|
         value = member[field]
+        value = member['private'][field] if value.nil? && member['private']
         [value, member['name']] unless value.nil?
       end.compact.to_h
+    end
+
+    # Returns the list of team members, with site.data['team']['private']
+    # members included.
+    def team_members
+      @team_members ||= team.map { |key, value| value unless key == 'private' }
+        .compact
+        .concat((team['private'] || {}).values)
     end
 
     # Replaces each member of team_list with a key into the team hash.

--- a/lib/team_api/joiner.rb
+++ b/lib/team_api/joiner.rb
@@ -144,7 +144,9 @@ module TeamApi
     # from team members not appearing in +site.data[+'team'] or
     # +team_by_email+.
     def join_snippet_data
-      data['snippets'] = data['snippets'].map do |timestamp, snippets|
+      raw_snippets = data['snippets']
+      return if raw_snippets.nil?
+      data['snippets'] = raw_snippets.map do |timestamp, snippets|
         joined = snippets.map { |snippet| join_snippet snippet }
           .compact.each { |i| i.delete 'username' }
         [timestamp, joined] unless joined.empty?

--- a/test/joiner_join_project_data_test.rb
+++ b/test/joiner_join_project_data_test.rb
@@ -20,22 +20,25 @@ module TeamApi
       collection.docs << doc
     end
 
+    def project_self_link(name)
+      File.join Api.baseurl(@site), 'projects', name
+    end
+
     def test_join_project
-      impl = JoinerImpl.new @site
-      impl.data.merge! impl.collection_data
-      impl.promote_or_remove_data
-      impl.join_project_data
+      Joiner.join_data @site
       assert_equal(
-        { 'msb-usa' => { 'name' => 'MSB-USA', 'status' => 'Hold' } },
+        { 'msb-usa' =>
+          {
+            'name' => 'MSB-USA', 'status' => 'Hold',
+            'self' => project_self_link('msb-usa')
+          },
+        },
         @site.data['projects'])
     end
 
     def test_hide_hold_projects_in_public_mode
       @site.config['public'] = true
-      impl = JoinerImpl.new @site
-      impl.data.merge! impl.collection_data
-      impl.promote_or_remove_data
-      impl.join_project_data
+      Joiner.join_data @site
       assert_empty @site.data['projects']
     end
   end

--- a/test/joiner_join_snippet_data_test.rb
+++ b/test/joiner_join_snippet_data_test.rb
@@ -39,14 +39,18 @@ module TeamApi
     end
 
     def add_expected_snippet(snippet, timestamp, name, full_name)
-      snippet = snippet.merge 'name' => name, 'full_name' => full_name
+      snippet = snippet.merge(
+        'name' => name,
+        'full_name' => full_name,
+        'self' => File.join(Api.baseurl(@site), 'team', name),
+      )
       snippet.delete 'username'
       (@expected[timestamp] ||= []) << snippet
     end
 
     def test_empty_snippet_data
       self.team = {}
-      @impl.join_snippet_data
+      Joiner.join_data @site
       assert_empty @site.data['snippets']
     end
 
@@ -58,7 +62,7 @@ module TeamApi
         '', '- Did stuff', '', expected: false)
       add_snippet('20141231', 'mbland', 'Mike Bland', 'michael.bland@gsa.gov',
         'Public', '- Did stuff', '', expected: false)
-      assert_raises(UnknownSnippetUsernameError) { @impl.join_snippet_data }
+      assert_raises(UnknownSnippetUsernameError) { Joiner.join_data @site }
     end
 
     def test_joined_snippets_are_empty_if_no_team_in_public_mode
@@ -71,7 +75,7 @@ module TeamApi
         'Public', '- Did stuff', '', expected: false)
 
       set_public_mode
-      @impl.join_snippet_data
+      Joiner.join_data @site
       assert_empty @site.data['snippets']
     end
 
@@ -89,7 +93,7 @@ module TeamApi
         '', '- Did stuff', '')
       add_snippet('20141231', 'mbland', 'Mike Bland', 'michael.bland@gsa.gov',
         'Public', '- Did stuff', '')
-      @impl.join_snippet_data
+      Joiner.join_data @site
       assert_equal @expected, @site.data['snippets']
     end
     # rubocop:enable MethodLength
@@ -113,7 +117,7 @@ module TeamApi
       add_snippet('20141231', 'mbland', 'Mike Bland', 'mbland',
         'Public', '- Did stuff', '')
 
-      @impl.join_snippet_data
+      Joiner.join_data @site
       assert_equal @expected, @site.data['snippets']
     end
     # rubocop:enable MethodLength

--- a/test/joiner_join_snippet_data_test.rb
+++ b/test/joiner_join_snippet_data_test.rb
@@ -6,6 +6,7 @@ require 'minitest/autorun'
 require 'weekly_snippets/version'
 
 module TeamApi
+  # rubocop:disable ClassLength
   class JoinSnippetDataTest < ::Minitest::Test
     def setup
       @site = DummyTestSite.new
@@ -40,9 +41,8 @@ module TeamApi
 
     def add_expected_snippet(snippet, timestamp, name, full_name)
       snippet = snippet.merge(
-        'name' => name,
-        'full_name' => full_name,
-        'self' => File.join(Api.baseurl(@site), 'team', name),
+        'name' => name, 'full_name' => full_name,
+        'self' => File.join(Api.baseurl(@site), 'team', name)
       )
       snippet.delete 'username'
       (@expected[timestamp] ||= []) << snippet
@@ -98,6 +98,25 @@ module TeamApi
     end
     # rubocop:enable MethodLength
 
+    # rubocop:disable MethodLength
+    def test_join_all_snippets_when_user_email_is_private
+      self.team = {
+        'mbland' => {
+          'name' => 'mbland', 'full_name' => 'Mike Bland',
+          'private' => { 'email' => 'michael.bland@gsa.gov' }
+        },
+      }
+      add_snippet('20141218', 'mbland', 'Mike Bland', 'michael.bland@gsa.gov',
+        'unused', '- Did stuff', '')
+      add_snippet('20141225', 'mbland', 'Mike Bland', 'michael.bland@gsa.gov',
+        '', '- Did stuff', '')
+      add_snippet('20141231', 'mbland', 'Mike Bland', 'michael.bland@gsa.gov',
+        'Public', '- Did stuff', '')
+      Joiner.join_data @site
+      assert_equal @expected, @site.data['snippets']
+    end
+    # rubocop:enable MethodLength
+
     # This tests the case where we're publishing snippets imported into
     # _data/public using _data/import-public.rb. That script will substitute
     # the original snippets' email usernames with the corresponding Hub
@@ -122,4 +141,5 @@ module TeamApi
     end
     # rubocop:enable MethodLength
   end
+  # rubocop:enable ClassLength
 end

--- a/test/joiner_team_index_by_field_test.rb
+++ b/test/joiner_team_index_by_field_test.rb
@@ -33,7 +33,6 @@ module TeamApi
     def impl
       joiner_impl = JoinerImpl.new @site
       joiner_impl.data.merge! joiner_impl.collection_data
-      joiner_impl.promote_or_remove_data
       joiner_impl
     end
 


### PR DESCRIPTION
This was causing many snippets to not appear in public mode because their
authors have their email listed as `private:`.

cc: @arowla @jessieay @monfresh 