### PR TITLE
Ensure that the /public/api index is generated

### DIFF
--- a/lib/team_api/api.rb
+++ b/lib/team_api/api.rb
@@ -13,7 +13,7 @@ module TeamApi
     def initialize(site)
       @site = site
       @base = site.source
-      @dir = File.join site.config['baseurl'], Api::BASEURL
+      @dir = Api::BASEURL
       @name = 'index.html'
       @data = {}
     end

--- a/test/api_test.rb
+++ b/test/api_test.rb
@@ -84,6 +84,12 @@ module TeamApi
       assert_equal ['/api/'], site.pages.map(&:url)
     end
 
+    def test_generate_public_api_with_no_data
+      site.config['baseurl'] = '/public'
+      Api.generate_api site
+      assert_equal ['/api/'], site.pages.map(&:url)
+    end
+
     def test_generate_api_team
       site.data['team'] = {
         'mbland' => { 'name' => 'mbland', 'full_name' => 'Mike Bland' },


### PR DESCRIPTION
Before this change, it was getting written to /public/public/api.

cc: @arowla @jessieay 