### PR TITLE
Writing cross-referencing errors to the output instead of throwing exceptions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: ruby
+sudo: false
+script: ./go ci_build
+rvm:
+- 2.2.3

--- a/lib/team_api/joiner.rb
+++ b/lib/team_api/joiner.rb
@@ -17,23 +17,79 @@ module TeamApi
     def self.join_data(site)
       impl = JoinerImpl.new site
       site.data.merge! impl.collection_data
-      impl.create_indexes
       impl.promote_or_remove_data
+      impl.init_team_data site.data['team']
       impl.join_project_data
       Api.add_self_links site
       impl.join_snippet_data
     end
   end
 
+  class TeamIndexer
+    def initialize(data)
+      @team = data
+    end
+
+    def team
+      @team || {}
+    end
+
+    def create_indexes
+      team_by_email
+      team_by_github
+    end
+
+    # Returns an index of team member usernames keyed by email address.
+    def team_by_email
+      @team_by_email ||= team_index_by_field 'email'
+    end
+
+    # Returns an index of team member usernames keyed by email address.
+    def team_by_github
+      @team_by_github ||= team_index_by_field 'github'
+    end
+
+    # Returns an index of team member usernames keyed by a particular field.
+    def team_index_by_field(field)
+      team_members.map do |member|
+        value = member[field]
+        value = member['private'][field] if value.nil? && member['private']
+        [value, member['name']] unless value.nil?
+      end.compact.to_h
+    end
+
+    # Returns the list of team members, with site.data['team']['private']
+    # members included.
+    def team_members
+      @team_members ||= team.map { |key, value| value unless key == 'private' }
+        .compact
+        .concat((team['private'] || {}).values)
+    end
+
+    def team_member_key(ref)
+      (ref.is_a? String) ? ref : (ref['id'] || ref['email'] || ref['github'])
+    end
+
+    def team_member_from_reference(reference)
+      key = team_member_key reference
+      team[key] || team[team_by_email[key] || team_by_github[key]]
+    end
+  end
+
   # Implements Joiner operations.
   class JoinerImpl
-    attr_reader :site, :data, :public_mode
+    attr_reader :site, :data, :public_mode, :team_indexer
 
     # +site+:: Jekyll site data object
     def initialize(site)
       @site = site
       @data = site.data
       @public_mode = site.config['public']
+    end
+
+    def init_team_data(data)
+      @team_indexer = TeamIndexer.new data
+      team_indexer.create_indexes
     end
 
     def collection_data
@@ -79,42 +135,6 @@ module TeamApi
       end
     end
 
-    def team
-      data['team'] ||= {}
-    end
-
-    def create_indexes
-      team_by_email
-      team_by_github
-    end
-
-    # Returns an index of team member usernames keyed by email address.
-    def team_by_email
-      @team_by_email ||= team_index_by_field 'email'
-    end
-
-    # Returns an index of team member usernames keyed by email address.
-    def team_by_github
-      @team_by_github ||= team_index_by_field 'github'
-    end
-
-    # Returns an index of team member usernames keyed by a particular field.
-    def team_index_by_field(field)
-      team_members.map do |member|
-        value = member[field]
-        value = member['private'][field] if value.nil? && member['private']
-        [value, member['name']] unless value.nil?
-      end.compact.to_h
-    end
-
-    # Returns the list of team members, with site.data['team']['private']
-    # members included.
-    def team_members
-      @team_members ||= team.map { |key, value| value unless key == 'private' }
-        .compact
-        .concat((team['private'] || {}).values)
-    end
-
     # Replaces each member of team_list with a key into the team hash.
     # Values can be:
     # - Strings that are already team hash keys
@@ -124,24 +144,15 @@ module TeamApi
     # - Hashes that contain a 'github' property
     def join_team_list(team_list, errors)
       (team_list || []).map! do |reference|
-        member = team_member_from_reference reference
+        member = @team_indexer.team_member_from_reference reference
         if member.nil?
           errors << 'Unknown Team Member: ' +
-            team_member_key(reference) unless public_mode
+            @team_indexer.team_member_key(reference) unless public_mode
           nil unless public_mode
         else
           member['name']
         end
       end.compact! || []
-    end
-
-    def team_member_key(ref)
-      (ref.is_a? String) ? ref : (ref['id'] || ref['email'] || ref['github'])
-    end
-
-    def team_member_from_reference(reference)
-      key = team_member_key reference
-      team[key] || team[team_by_email[key] || team_by_github[key]]
     end
 
     SNIPPET_JOIN_FIELDS = %w(name full_name first_name last_name self)
@@ -161,7 +172,7 @@ module TeamApi
 
     def join_snippet(snippet)
       username = snippet['username']
-      member = team[username] || team[team_by_email[username]]
+      member = @team_indexer.team_member_from_reference username
 
       if member.nil?
         fail UnknownSnippetUsernameError, username unless public_mode

--- a/lib/team_api/joiner.rb
+++ b/lib/team_api/joiner.rb
@@ -144,10 +144,10 @@ module TeamApi
     # - Hashes that contain a 'github' property
     def join_team_list(team_list, errors)
       (team_list || []).map! do |reference|
-        member = @team_indexer.team_member_from_reference reference
+        member = team_indexer.team_member_from_reference reference
         if member.nil?
           errors << 'Unknown Team Member: ' +
-            @team_indexer.team_member_key(reference)
+            team_indexer.team_member_key(reference)
           nil
         else
           member['name']
@@ -172,7 +172,7 @@ module TeamApi
 
     def join_snippet(snippet)
       username = snippet['username']
-      member = @team_indexer.team_member_from_reference username
+      member = team_indexer.team_member_from_reference username
 
       if member.nil?
         fail UnknownSnippetUsernameError, username unless public_mode

--- a/lib/team_api/joiner.rb
+++ b/lib/team_api/joiner.rb
@@ -147,8 +147,8 @@ module TeamApi
         member = @team_indexer.team_member_from_reference reference
         if member.nil?
           errors << 'Unknown Team Member: ' +
-            @team_indexer.team_member_key(reference) unless public_mode
-          nil unless public_mode
+            @team_indexer.team_member_key(reference)
+          nil
         else
           member['name']
         end

--- a/test/joiner_join_team_list_test.rb
+++ b/test/joiner_join_team_list_test.rb
@@ -66,13 +66,13 @@ module TeamApi
       assert_equal 'Unknown Team Member: foobar', outerror[0]
     end
 
-    def test_join_ignores_unknown_identifiers_in_public_mode
+    def test_join_includes_unknown_identifiers_in_public_mode
       @site.config['public'] = true
       outlist = %w(mbland alison@18f.gov jmcarp foobar)
       outerror = []
       impl.join_team_list outlist, outerror
       assert_equal(%w(mbland alison joshcarp), outlist)
-      assert_empty outerror
+      assert_equal 'Unknown Team Member: foobar', outerror[0]
     end
   end
 end

--- a/test/joiner_join_team_list_test.rb
+++ b/test/joiner_join_team_list_test.rb
@@ -16,18 +16,21 @@ module TeamApi
       }
     end
 
-    def test_join_nil_team_list
+    def impl
       impl = JoinerImpl.new @site
+      impl.init_team_data @site.data['team']
+      impl
+    end
+
+    def test_join_nil_team_list
       assert_empty impl.join_team_list nil, nil
     end
 
     def test_join_empty_team_list
-      impl = JoinerImpl.new @site
       assert_empty impl.join_team_list [], []
     end
 
     def test_join_names_that_do_not_require_translation
-      impl = JoinerImpl.new @site
       outlist = %w(mbland alison joshcarp)
       outerror = []
       impl.join_team_list outlist, outerror
@@ -36,7 +39,6 @@ module TeamApi
     end
 
     def test_join_names_that_require_translation
-      impl = JoinerImpl.new @site
       outlist = %w(mbland alison@18f.gov jmcarp)
       outerror = []
       impl.join_team_list outlist, outerror
@@ -45,7 +47,6 @@ module TeamApi
     end
 
     def test_join_team_containing_hashes
-      impl = JoinerImpl.new @site
       outlist = [
         'mbland',
         { 'email' => 'alison@18f.gov' },
@@ -58,7 +59,6 @@ module TeamApi
     end
 
     def test_join_error_returned_if_identifier_unknown
-      impl = JoinerImpl.new @site
       outlist = %w(mbland alison@18f.gov jmcarp foobar)
       outerror = []
       impl.join_team_list outlist, outerror
@@ -68,7 +68,6 @@ module TeamApi
 
     def test_join_ignores_unknown_identifiers_in_public_mode
       @site.config['public'] = true
-      impl = JoinerImpl.new @site
       outlist = %w(mbland alison@18f.gov jmcarp foobar)
       outerror = []
       impl.join_team_list outlist, outerror

--- a/test/joiner_join_team_list_test.rb
+++ b/test/joiner_join_team_list_test.rb
@@ -18,8 +18,7 @@ module TeamApi
 
     def test_join_nil_team_list
       impl = JoinerImpl.new @site
-      outlist = nil
-      assert_empty impl.join_team_list nil, nil 
+      assert_empty impl.join_team_list nil, nil
     end
 
     def test_join_empty_team_list
@@ -51,8 +50,7 @@ module TeamApi
         'mbland',
         { 'email' => 'alison@18f.gov' },
         { 'github' => 'jmcarp' },
-        { 'id' => 'boone' },
-      ]
+        { 'id' => 'boone' }]
       outerror = []
       impl.join_team_list outlist, outerror
       assert_equal(%w(mbland alison joshcarp boone), outlist)
@@ -73,7 +71,7 @@ module TeamApi
       impl = JoinerImpl.new @site
       outlist = %w(mbland alison@18f.gov jmcarp foobar)
       outerror = []
-      impl.join_team_list outlist, outerror 
+      impl.join_team_list outlist, outerror
       assert_equal(%w(mbland alison joshcarp), outlist)
       assert_empty outerror
     end

--- a/test/joiner_join_team_list_test.rb
+++ b/test/joiner_join_team_list_test.rb
@@ -18,50 +18,64 @@ module TeamApi
 
     def test_join_nil_team_list
       impl = JoinerImpl.new @site
-      assert_empty impl.join_team_list nil
+      outlist = nil
+      assert_empty impl.join_team_list nil, nil 
     end
 
     def test_join_empty_team_list
       impl = JoinerImpl.new @site
-      assert_empty impl.join_team_list []
+      assert_empty impl.join_team_list [], []
     end
 
     def test_join_names_that_do_not_require_translation
       impl = JoinerImpl.new @site
-      assert_equal(%w(mbland alison joshcarp),
-        impl.join_team_list(%w(mbland alison joshcarp)))
+      outlist = %w(mbland alison joshcarp)
+      outerror = []
+      impl.join_team_list outlist, outerror
+      assert_equal(%w(mbland alison joshcarp), outlist)
+      assert_empty outerror
     end
 
     def test_join_names_that_require_translation
       impl = JoinerImpl.new @site
-      assert_equal(%w(mbland alison joshcarp),
-        impl.join_team_list(%w(mbland alison@18f.gov jmcarp)))
+      outlist = %w(mbland alison@18f.gov jmcarp)
+      outerror = []
+      impl.join_team_list outlist, outerror
+      assert_equal(%w(mbland alison joshcarp), outlist)
+      assert_empty outerror
     end
 
     def test_join_team_containing_hashes
       impl = JoinerImpl.new @site
-      assert_equal(%w(mbland alison joshcarp boone),
-        impl.join_team_list([
-          'mbland',
-          { 'email' => 'alison@18f.gov' },
-          { 'github' => 'jmcarp' },
-          { 'id' => 'boone' },
-        ]))
+      outlist = [
+        'mbland',
+        { 'email' => 'alison@18f.gov' },
+        { 'github' => 'jmcarp' },
+        { 'id' => 'boone' },
+      ]
+      outerror = []
+      impl.join_team_list outlist, outerror
+      assert_equal(%w(mbland alison joshcarp boone), outlist)
+      assert_empty outerror
     end
 
-    def test_join_raises_if_identifier_unknown
+    def test_join_error_returned_if_identifier_unknown
       impl = JoinerImpl.new @site
-      error = assert_raises(UnknownTeamMemberReferenceError) do
-        impl.join_team_list(%w(mbland alison@18f.gov jmcarp foobar))
-      end
-      assert_equal 'foobar', error.message
+      outlist = %w(mbland alison@18f.gov jmcarp foobar)
+      outerror = []
+      impl.join_team_list outlist, outerror
+      assert_equal(%w(mbland alison joshcarp), outlist)
+      assert_equal 'Unknown Team Member: foobar', outerror[0]
     end
 
     def test_join_ignores_unknown_identifiers_in_public_mode
       @site.config['public'] = true
       impl = JoinerImpl.new @site
-      assert_equal(%w(mbland alison joshcarp),
-        impl.join_team_list(%w(mbland alison@18f.gov jmcarp foobar)))
+      outlist = %w(mbland alison@18f.gov jmcarp foobar)
+      outerror = []
+      impl.join_team_list outlist, outerror 
+      assert_equal(%w(mbland alison joshcarp), outlist)
+      assert_empty outerror
     end
   end
 end

--- a/test/joiner_team_index_by_field_test.rb
+++ b/test/joiner_team_index_by_field_test.rb
@@ -33,7 +33,8 @@ module TeamApi
     def impl
       joiner_impl = JoinerImpl.new @site
       joiner_impl.data.merge! joiner_impl.collection_data
-      joiner_impl
+      joiner_impl.init_team_data joiner_impl.data['team']
+      joiner_impl.team_indexer
     end
 
     def test_empty_team


### PR DESCRIPTION
Changing joiner.rb to add an errors array to the project hash instead of throwing UnknownTeamMemberReferenceError if there isn't a legit team mate.

I am not a Rubyist. Please let me know if there is a better/more paradigmatic way to do what I've done. :)

This is in reference to https://github.com/18F/team-api.18f.gov/issues/122