### PR TITLE
Adding support for an errors endpoint.

### DIFF
--- a/lib/team_api/api.rb
+++ b/lib/team_api/api.rb
@@ -18,6 +18,7 @@ module TeamApi
       generate_collection_endpoints impl
       generate_tag_category_endpoints impl
       impl.generate_snippets_endpoints
+      impl.generate_error_endpoint
       IndexPage.create site, impl.index_endpoints
     end
 

--- a/lib/team_api/api_impl.rb
+++ b/lib/team_api/api_impl.rb
@@ -1,10 +1,12 @@
 require_relative 'endpoint'
 require_relative 'api_impl_snippet_helpers'
+require_relative 'api_impl_error_helpers'
 
 module TeamApi
   class ApiImpl
     attr_accessor :site, :data, :index_endpoints, :baseurl
     include ApiImplSnippetHelpers
+    include ApiImplErrorHelpers
 
     def initialize(site, baseurl)
       @site = site
@@ -58,6 +60,11 @@ module TeamApi
       generate_snippets_by_date_endpoints
       generate_snippets_by_user_endpoints
       generate_snippets_index_summary_endpoint
+    end
+
+    def generate_error_endpoint
+      generate_errors_endpoint
+      generate_errors_index_summary_endpoint
     end
   end
 end

--- a/lib/team_api/api_impl_error_helpers.rb
+++ b/lib/team_api/api_impl_error_helpers.rb
@@ -1,0 +1,34 @@
+module TeamApi
+  module ApiImplErrorHelpers
+    private
+
+    def errors
+      @errors ||= (data['errors'] || {})
+    end
+
+    def missing
+      @missing ||= (data['missing'] || {})
+    end
+
+    def error_summary
+      @error_summary ||= {
+        'errors' => errors,
+        'missing' => missing,
+      }
+    end
+
+    def generate_errors_endpoint
+      return if errors.empty? && missing.empty?
+      endpoint = 'errors'
+      Endpoint.create(site, "#{baseurl}/#{endpoint}", error_summary)
+    end
+
+    def generate_errors_index_summary_endpoint
+      return if errors.empty? && missing.empty?
+      generate_index_endpoint(
+        'errors', 'Errors', '.about.yml parsing errors and ' \
+        'repos missing a .about.yml file.',
+        error_summary)
+    end
+  end
+end

--- a/lib/team_api/joiner.rb
+++ b/lib/team_api/joiner.rb
@@ -131,8 +131,14 @@ module TeamApi
       projects.values.each do |p|
         errors = p['errors'] || []
         join_team_list p['team'], errors
-        p['errors'] = errors unless errors.empty?
+        store_project_errors p, errors unless errors.empty?
       end
+    end
+
+    def store_project_errors(project, errors)
+      project['errors'] = errors
+      name = project['github'][0] || project['name']
+      data['errors'][name] |= errors unless data['errors'].nil?
     end
 
     # Replaces each member of team_list with a key into the team hash.

--- a/test/errors_api_test.rb
+++ b/test/errors_api_test.rb
@@ -1,0 +1,58 @@
+require_relative 'test_helper'
+
+module TeamApi
+  class ErrorsApiTest < ::Minitest::Test
+    attr_accessor :site
+
+    def setup
+      @site = DummyTestSite.new
+
+      site.data['team'] = {
+        'mbland' => { 'name' => 'mbland', 'full_name' => 'Mike Bland' },
+      }
+      site.data['errors'] = {
+        'projA' => %w(Error1 Error2),
+        'projB' => ['Error3'],
+      }
+      site.data['missing'] = %w(projC projD)
+
+      Api.generate_api site
+    end
+
+    def expected_endpoints
+      [
+        '/api/',
+        '/api/errors/api.json',
+        '/api/team/api.json',
+        '/api/team/mbland/api.json',
+      ]
+    end
+
+    def pages
+      site.pages.map { |page| [page.url, page] }.to_h
+    end
+
+    def errors
+      site.data['errors']
+    end
+
+    def test_all_endpoints_present
+      assert_equal expected_endpoints.sort, pages.keys.sort
+    end
+
+    def parse_page_content(page_url)
+      JSON.parse pages[page_url].content
+    end
+
+    def test_error_summary
+      expected = {
+        'errors' => {
+          'projA' => %w(Error1 Error2),
+          'projB' => ['Error3'],
+        },
+        'missing' => %w(projC projD),
+      }
+      assert_equal expected, parse_page_content('/api/errors/api.json')
+    end
+  end
+end


### PR DESCRIPTION
Errors are exposed at api/errors. The errors endpoint contains yaml parsing errors, .about.yml schema errors, unknown team member errors, and all repos that are missing an .about.yml.

The unknown team member errors are added here. The other types of errors are logged in the team-api.18f.gov repo, PR is forthcoming. :)