### PR TITLE
Correcting an bug where the project specific errors being applied.

### DIFF
--- a/lib/team_api/joiner.rb
+++ b/lib/team_api/joiner.rb
@@ -138,7 +138,7 @@ module TeamApi
     def store_project_errors(project, errors)
       project['errors'] = errors
       name = project['github'][0] || project['name']
-      data['errors'][name] |= errors unless data['errors'].nil?
+      data['errors'][name] = (data['errors'][name] || []) | errors
     end
 
     # Replaces each member of team_list with a key into the team hash.

--- a/lib/team_api/joiner.rb
+++ b/lib/team_api/joiner.rb
@@ -138,7 +138,7 @@ module TeamApi
     def store_project_errors(project, errors)
       project['errors'] = errors
       name = project['github'][0] || project['name']
-      data['errors'][name] = (data['errors'][name] || []) | errors
+      data['errors'][name] = errors
     end
 
     # Replaces each member of team_list with a key into the team hash.

--- a/test/joiner_join_project_data_test.rb
+++ b/test/joiner_join_project_data_test.rb
@@ -50,17 +50,17 @@ module TeamApi
 
     def project_data_with_errors
       with_errors = project_data
-      project_data['errors'] = %w(error1 error2)
+      with_errors['errors'] = %w(error1 error2)
       with_errors
     end
 
-    def error_joiner_impl(errors)
+    def error_joiner_impl(errors = {})
       @site.data['errors'] = errors
       JoinerImpl.new @site
     end
 
     def test_store_project_data_new_error
-      joiner = error_joiner_impl({})
+      joiner = error_joiner_impl
       project = project_data
       joiner.store_project_errors project, ['error!']
       assert_equal ['error!'], project['errors']
@@ -68,19 +68,11 @@ module TeamApi
     end
 
     def test_store_project_data_new_error_with_project_errors
-      joiner = error_joiner_impl({})
+      joiner = error_joiner_impl
       project = project_data_with_errors
       joiner.store_project_errors project, %w(error1 error2 error!)
       assert_equal %w(error1 error2 error!), project['errors']
       assert_equal %w(error1 error2 error!), @site.data['errors']['test_fm']
-    end
-
-    def test_store_project_data_new_error_with_data_errors
-      joiner = error_joiner_impl('test_fm' => ['error!'])
-      project = project_data_with_errors
-      joiner.store_project_errors project, %w(error1 error2)
-      assert_equal %w(error1 error2), project['errors']
-      assert_equal %w(error! error1 error2), @site.data['errors']['test_fm']
     end
 
     def test_store_project_data_new_error_with_other_data_errors


### PR DESCRIPTION
For repos where there were no errors before joining, the repos were writing `true` to the errors file instead of the errors. This corrects the issue, and adds tests to prevent this from happening in the future.