### PR TITLE
Connects #1:  Make GitHub usernames case insensitive in the Team API.

### DIFF
--- a/lib/team_api/joiner.rb
+++ b/lib/team_api/joiner.rb
@@ -44,7 +44,7 @@ module TeamApi
       @team_by_email ||= team_index_by_field 'email'
     end
 
-    # Returns an index of team member usernames keyed by email address.
+    # Returns an index of team member usernames keyed by GitHub username.
     def team_by_github
       @team_by_github ||= team_index_by_field 'github'
     end
@@ -54,6 +54,7 @@ module TeamApi
       team_members.map do |member|
         value = member[field]
         value = member['private'][field] if value.nil? && member['private']
+        value = value.downcase if field == 'github' && !value.nil?
         [value, member['name']] unless value.nil?
       end.compact.to_h
     end
@@ -72,7 +73,7 @@ module TeamApi
 
     def team_member_from_reference(reference)
       key = team_member_key reference
-      team[key] || team[team_by_email[key] || team_by_github[key]]
+      team[key] || team[team_by_email[key] || team_by_github[key.downcase]]
     end
   end
 

--- a/test/joiner_join_team_list_test.rb
+++ b/test/joiner_join_team_list_test.rb
@@ -9,6 +9,7 @@ module TeamApi
         'alison' => { 'name' => 'alison', 'email' => 'alison@18f.gov' },
         'joshcarp' => { 'name' => 'joshcarp', 'github' => 'jmcarp' },
         'boone' => { 'name' => 'boone' },
+        'leah' => { 'name' => 'leah', 'github' => 'LeahBannon' }
       }
     end
 
@@ -54,6 +55,32 @@ module TeamApi
       assert_empty outerror
     end
 
+    def test_join_team_containing_hashes_with_case_insensitive_identifiers
+      outlist = [
+        'mbland',
+        { 'email' => 'alison@18f.gov' },
+        { 'github' => 'jmcarp' },
+        { 'github' => 'leahbannon'},
+        { 'id' => 'boone' }]
+      outerror = []
+      impl.join_team_list outlist, outerror
+      assert_equal(%w(mbland alison joshcarp leah boone), outlist)
+      assert_empty outerror
+    end
+
+    def test_join_team_containing_hashes_with_capitalized_identifiers
+      outlist = [
+        'mbland',
+        { 'email' => 'alison@18f.gov' },
+        { 'github' => 'jmcarp' },
+        { 'github' => 'LeahBannon'},
+        { 'id' => 'boone' }]
+      outerror = []
+      impl.join_team_list outlist, outerror
+      assert_equal(%w(mbland alison joshcarp leah boone), outlist)
+      assert_empty outerror
+    end
+
     def test_join_error_returned_if_identifier_unknown
       outlist = %w(mbland alison@18f.gov jmcarp foobar)
       outerror = []
@@ -69,6 +96,22 @@ module TeamApi
       impl.join_team_list outlist, outerror
       assert_equal(%w(mbland alison joshcarp), outlist)
       assert_equal 'Unknown Team Member: foobar', outerror[0]
+    end
+
+    def test_join_includes_case_insensitive_identifiers
+      outlist = %w(mbland alison@18f.gov jmcarp leahbannon)
+      outerror = []
+      impl.join_team_list outlist, outerror
+      assert_equal(%w(mbland alison joshcarp leah), outlist)
+      assert_empty outerror
+    end
+
+    def test_join_includes_capitalized_identifiers
+      outlist = %w(mbland alison@18f.gov jmcarp LeahBannon)
+      outerror = []
+      impl.join_team_list outlist, outerror
+      assert_equal(%w(mbland alison joshcarp leah), outlist)
+      assert_empty outerror
     end
   end
 end


### PR DESCRIPTION
This changeset makes the handling of GitHub usernames case insensitive when importing data into the Team API and adds several test cases to capture the scenarios in which this kind of problem can occur.  Ultimately we want it to be easy to just import an .about.yml file and not have to worry whether or not the GitHub usernames match.