### PR TITLE
Downcase filenames when saving. Connects #48

### DIFF
--- a/lib/team_api/front_matter.rb
+++ b/lib/team_api/front_matter.rb
@@ -17,7 +17,7 @@ module TeamApi
       content = content[end_front_matter..-1]
       front_matter = SafeYAML.load front_matter, safe: true
       yield front_matter
-      File.write filename, "#{front_matter.to_yaml}#{content}"
+      File.write filename.downcase, "#{front_matter.to_yaml}#{content}"
     end
 
     def self.front_matter_end_index(filename, content)


### PR DESCRIPTION
Should be merged shortly after https://github.com/18F/team-api.18f.gov/pull/174 (and not before!) so that automatic file renaming doesn't completely mess up Git/AppleOS again.