### PR TITLE
Closes #57:  Remove Jekyll `site.collections` munging

### DIFF
--- a/lib/team_api/canonicalizer.rb
+++ b/lib/team_api/canonicalizer.rb
@@ -19,7 +19,7 @@ module TeamApi
     # Returns a canonicalized, URL-friendly substitute for an arbitrary string.
     # +s+:: string to canonicalize
     def self.canonicalize(s)
-      s.downcase.gsub(/\s+/, '-')
+      s.downcase.gsub(/\s+/, '-') unless s.nil?
     end
 
     def self.team_xrefs(team, usernames)

--- a/lib/team_api/version.rb
+++ b/lib/team_api/version.rb
@@ -1,5 +1,5 @@
 # @author Mike Bland (michael.bland@gsa.gov)
 
 module TeamApi
-  VERSION = '0.0.10'
+  VERSION = '0.0.12'
 end

--- a/test/joiner_join_project_data_test.rb
+++ b/test/joiner_join_project_data_test.rb
@@ -4,16 +4,17 @@ module TeamApi
   class JoinProjectDataTest < ::Minitest::Test
     def setup
       config = {
-        'source' => '/',
-        'collections' => { 'projects' => { 'output' => true } },
+        'source' => '/'
       }
       @site = DummyTestSite.new config: config
-      collection = @site.collections['projects']
-      doc = ::Jekyll::Document.new(
-        '/_projects/msb-usa.md', site: @site, collection: collection)
-      doc.data.merge! 'name' => 'MSB-USA', 'status' => 'Hold'
-      doc.data.delete 'draft'
-      collection.docs << doc
+      @site.data = {
+        'projects' => {
+          'msb-usa' => {
+            'name' => 'MSB-USA',
+            'status' => 'Hold'
+          }
+        }
+      }
     end
 
     def project_self_link(name)
@@ -26,8 +27,7 @@ module TeamApi
         { 'msb-usa' =>
           {
             'name' => 'MSB-USA', 'status' => 'Hold',
-            'self' => project_self_link('msb-usa'),
-            'categories' => []
+            'self' => project_self_link('msb-usa')
           },
         },
         @site.data['projects'])

--- a/test/site.rb
+++ b/test/site.rb
@@ -10,7 +10,7 @@ module TeamApi
       'permalink' => 'pretty',
       'baseurl' => '',
       'url' => 'https://team-api.18f.gov',
-      'api_index_layout' => 'api_index.html',
+      'api_index_layout' => 'api_index.html'
     }
 
     def initialize(config: {})


### PR DESCRIPTION
This changeset removes the processing around the Jekyll `site.collections` hash since we are now dealing with the YAML files directly for the Team API.  This means that everything is already in the `site.data` hash instead.  Some additional processing was added to make sure the `site.data` hash has the correct keys.